### PR TITLE
add stats to nxos json gatherers, bug fix in stats filter

### DIFF
--- a/docs/filter/stats.md
+++ b/docs/filter/stats.md
@@ -41,7 +41,7 @@ ansible_facts:
         - state
 
 ansible_facts:
-  interface_stats:
+  stats:
     count_by_speed:
       '1000': 1
       auto: 130

--- a/docs/module/cli_parse_transform.md
+++ b/docs/module/cli_parse_transform.md
@@ -36,6 +36,7 @@ Additionally `cli_parse_transform` can generate statisitics from the parsed data
 
 - `engine`: (required) Specific the parsing engine to be used, either `native_json`, `native_xml` or `pyats`. For `pyats` the pyats python library needs to be installed on the ansible control node. For `native_xml` the `xmltodict` python library needs to be installed
 - `ignore_parser_errors` (optional, bool, default=False) Allow the task to continue when parsing errors are found
+- `only_stats` (optional, bool, default=False) Only return summary statisitics for each of the gathered
 - `commands`: (required) A list of commands to be run on the network device and parsed. Each entry in the list of `commands` has the following parameters available:
   - `command`: (required) The command to be issued on the network device
   - `set_fact`: (optional) Set the parser output as an Ansible fact for the host in play.

--- a/examples/gather_states/dev.yaml
+++ b/examples/gather_states/dev.yaml
@@ -1,0 +1,14 @@
+- hosts: nxos101
+  gather_facts: false
+  roles:
+  - role: nmake.jetpack.gather_states
+    only_stats: True
+    fact_key: before
+    gather_states:
+    - all
+    - '!vpc'
+  tasks:
+  - debug:
+      var: ansible_facts
+  - debug:
+      msg: "{{ ansible_facts['before']|nmake.jetpack.to_dotted }}"

--- a/plugins/filter/stats.py
+++ b/plugins/filter/stats.py
@@ -3,8 +3,9 @@ from ansible.errors import AnsibleFilterError
 from ansible.module_utils.network.common.utils import dict_merge
 from collections import Counter
 
+import q
 
-def _stats(parsed, key, statsd):
+def _stats(parsed, key, statsd, missing_key="unknown"):
     if isinstance(parsed, list):
         working = []
         for entry in parsed:
@@ -21,18 +22,23 @@ def _stats(parsed, key, statsd):
             counts = None
             if isinstance(res, dict):
                 try:
-                    counts = dict(Counter(cval[key]
-                                          for ckey, cval in res.items()))
+                    if any(key in cval for ckey, cval in res.items()):
+                        counts = dict(Counter(cval.get(key, missing_key)
+                                              for ckey, cval in res.items()))
                 except (AttributeError, TypeError, KeyError):
                     pass
             if isinstance(res, list):
                 try:
-                    counts = dict(Counter(cval[key] for cval in res))
+                    if any(key in cval for cval in res):
+                        counts = dict(Counter(cval.get(key, missing_key)
+                                              for cval in res))
                 except (AttributeError, TypeError, KeyError):
                     pass
             if counts:
-                stats_dict = {k + "_stats": {'count_by_' + key: counts,
-                                             'total': len(res)}}
+                ckey = 'count_by_' + key
+                count_dict = {ckey: counts}
+                count_dict[ckey]['total'] = len(res)
+                stats_dict = {"stats": count_dict}
                 working = dict_merge(working, stats_dict)
                 statsd = dict_merge(statsd, stats_dict)
         return working, statsd

--- a/plugins/filter/stats.py
+++ b/plugins/filter/stats.py
@@ -3,7 +3,6 @@ from ansible.errors import AnsibleFilterError
 from ansible.module_utils.network.common.utils import dict_merge
 from collections import Counter
 
-import q
 
 def _stats(parsed, key, statsd, missing_key="unknown"):
     if isinstance(parsed, list):

--- a/roles/gather_states/defaults/main.yaml
+++ b/roles/gather_states/defaults/main.yaml
@@ -1,5 +1,6 @@
 ---
 fact_key: "gathered_states"
+only_stats: False
 
 available_gather:
 - "arp"

--- a/roles/gather_states/includes/nxos/json/arp.yaml
+++ b/roles/gather_states/includes/nxos/json/arp.yaml
@@ -7,6 +7,11 @@
         set_fact: True
         transform:
         - name: "nxos_flatten_table_row"
+        - name: stats
+          only_stats: "{{ only_stats }}"
+          keys:
+          - intf-out
+          - vrf-name-out
         - name: set_root_key
           key: arp
         - name: set_root_key

--- a/roles/gather_states/includes/nxos/json/cdp.yaml
+++ b/roles/gather_states/includes/nxos/json/cdp.yaml
@@ -7,6 +7,11 @@
         set_fact: True
         transform:
         - name: "nxos_flatten_table_row"
+        - name: stats
+          only_stats: "{{ only_stats }}"
+          keys:
+          - intf_id
+          - platform_id
         - name: set_root_key
           key: neighbors
         - name: set_root_key
@@ -22,6 +27,13 @@
         set_fact: True
         transform:
         - name: "nxos_flatten_table_row"
+        - name: stats
+          only_stats: "{{ only_stats }}"
+          keys:
+          - cdp_intf_enabled
+          - port_up
+        - name: set_root_key
+          key: interfaces
         - name: replace_keys
           keys:
           - before: '^cdp_all$'

--- a/roles/gather_states/includes/nxos/json/fex.yaml
+++ b/roles/gather_states/includes/nxos/json/fex.yaml
@@ -11,6 +11,7 @@
           key: "fex"
         - name: set_root_key
           key: "{{ fact_key }}"
+  when: not only_stats
 
 - name: "nxos.fex: show fex detail"
   nmake.jetpack.cli_parse_transform:
@@ -26,3 +27,4 @@
           key: "fex"
         - name: set_root_key
           key: "{{ fact_key }}"
+  when: not only_stats

--- a/roles/gather_states/includes/nxos/json/hardware.yaml
+++ b/roles/gather_states/includes/nxos/json/hardware.yaml
@@ -12,3 +12,4 @@
           key: hardware
         - name: set_root_key
           key: "{{ fact_key }}"
+  when: not only_stats

--- a/roles/gather_states/includes/nxos/json/interfaces.yaml
+++ b/roles/gather_states/includes/nxos/json/interfaces.yaml
@@ -8,6 +8,15 @@
         transform:
         - name: "nxos_flatten_table_row"
           plural: true
+        - name: stats
+          only_stats: "{{ only_stats }}"
+          keys:
+          - admin_state
+          - state
+          - state_rsn_desc
+          - eth_hw_desc
+          - eth_duplex
+          - eth_bw
         - name: set_root_key
           key: interfaces
         - name: set_root_key
@@ -18,31 +27,41 @@
     engine: "native_json"
     commands:
     - command: "show interface counters errors"
-      set_fact: False
+      set_fact: True
       transform:
       - name: "str_to_native"
       - name: "nxos_flatten_table_row"
+        plural: True
       - name: set_root_key
         key: errors
       - name: set_root_key
         key: counters
       - name: set_root_key
-        key: interface
+        key: interfaces
       - name: set_root_key
         key: "{{ fact_key }}"
+  when: not only_stats
 
 - name: "nxos.interfaces: show interface switchport"
   nmake.jetpack.cli_parse_transform:
     engine: "native_json"
     commands:
     - command: "show interface switchport"
-      set_fact: False
+      set_fact: True
       transform:
       - name: "nxos_flatten_table_row"
+        plural: True
+      - name: stats
+        only_stats: "{{ only_stats }}"
+        keys:
+        - access_vlan
+        - native_vlan
+        - oper_mode
+        - switchport
       - name: set_root_key
         key: switchport
       - name: set_root_key
-        key: interface
+        key: interfaces
       - name: set_root_key
         key: "{{ fact_key }}"
 
@@ -51,12 +70,17 @@
     engine: "native_json"
     commands:
     - command: "show interface transceiver"
-      set_fact: False
+      set_fact: True
       transform:
       - name: "nxos_flatten_table_row"
+        plural: True
+      - name: stats
+        only_stats: "{{ only_stats }}"
+        keys:
+        - sfp
       - name: set_root_key
         key: transceiver
       - name: set_root_key
-        key: interface
+        key: interfaces
       - name: set_root_key
         key: "{{ fact_key }}"

--- a/roles/gather_states/includes/nxos/json/lldp.yaml
+++ b/roles/gather_states/includes/nxos/json/lldp.yaml
@@ -7,6 +7,10 @@
         set_fact: True
         transform:
         - name: "nxos_flatten_table_row"
+        - name: stats
+          only_stats: "{{ only_stats }}"
+          keys:
+          - l_port_id
         - name: "set_root_key"
           key: neighbors
         - name: "set_root_key"
@@ -22,6 +26,14 @@
         set_fact: True
         transform:
         - name: "nxos_flatten_table_row"
+        - name: stats
+          only_stats: "{{ only_stats }}"
+          keys:
+          - lldp_dcbx
+          - lldp_rx
+          - lldp_tx
+        - name: set_root_key
+          key: interfaces
         - name: replace_keys
           keys:
           - before: '^lldp_all$'

--- a/roles/gather_states/includes/nxos/json/mac.yaml
+++ b/roles/gather_states/includes/nxos/json/mac.yaml
@@ -13,3 +13,4 @@
           key: mac
         - name: set_root_key
           key: "{{ fact_key }}"
+  when: not only_stats

--- a/roles/gather_states/includes/nxos/json/spanning_tree.yaml
+++ b/roles/gather_states/includes/nxos/json/spanning_tree.yaml
@@ -13,6 +13,7 @@
           key: spanning_tree
         - name: set_root_key
           key: "{{ fact_key }}"
+  when: not only_stats
 
 - name: "nxos.spanning_tree: show spanning-tree inconsistentports"
   nmake.jetpack.cli_parse_transform:
@@ -28,6 +29,7 @@
           key: spanning_tree
         - name: set_root_key
           key: "{{ fact_key }}"
+  when: not only_stats
 
 - name: "nxos.spanning_tree: show spanning-tree active detail"
   nmake.jetpack.cli_parse_transform:
@@ -37,6 +39,28 @@
         set_fact: True
         transform:
         - name: "nxos_flatten_table_row"
+        - name: "str_to_native"
+        - name: stats
+          only_stats: "{{ only_stats }}"
+          keys:
+          - bpdu_filter
+          - bpdu_guard
+          - designated_bridge_priority
+          - designated_cost
+          - dispute
+          - inconsistency
+          - oper_bpdufilter
+          - oper_bpduguard
+          - oper_loopguard
+          - oper_networkport
+          - oper_p2p
+          - oper_portfast
+          - peer
+          - port_protocol
+          - port_tree_type
+          - role
+          - self_looped
+          - state
         - name: set_root_key
           key: detail
         - name: set_root_key
@@ -46,6 +70,7 @@
         - name: set_root_key
           key: "{{ fact_key }}"
 
+
 - name: "nxos.spanning_tree: show spanning-tree root detail"
   nmake.jetpack.cli_parse_transform:
     engine: "native_json"
@@ -54,6 +79,7 @@
         set_fact: True
         transform:
         - name: "nxos_flatten_table_row"
+        - name: "str_to_native"
         - name: set_root_key
           key: detail
         - name: set_root_key
@@ -62,3 +88,4 @@
           key: spanning_tree
         - name: set_root_key
           key: "{{ fact_key }}"
+  when: not only_stats

--- a/roles/gather_states/includes/nxos/json/system.yaml
+++ b/roles/gather_states/includes/nxos/json/system.yaml
@@ -14,3 +14,4 @@
           key: system
         - name: set_root_key
           key: "{{ fact_key }}"
+  when: not only_stats

--- a/roles/gather_states/includes/nxos/json/version.yaml
+++ b/roles/gather_states/includes/nxos/json/version.yaml
@@ -11,3 +11,4 @@
           key: version
         - name: set_root_key
           key: "{{ fact_key }}"
+  when: not only_stats

--- a/roles/gather_states/includes/nxos/json/vlan.private_vlan.yaml
+++ b/roles/gather_states/includes/nxos/json/vlan.private_vlan.yaml
@@ -13,3 +13,4 @@
           key: vlan
         - name: set_root_key
           key: "{{ fact_key }}"
+  when: not only_stats

--- a/roles/gather_states/includes/nxos/json/vlan.yaml
+++ b/roles/gather_states/includes/nxos/json/vlan.yaml
@@ -7,6 +7,10 @@
         set_fact: True
         transform:
         - name: "nxos_flatten_table_row"
+        - name: "stats"
+          only_stats: "{{ only_stats }}"
+          keys:
+          - vlanshowbr-vlanstate
         - name: set_root_key
           key: vlan
         - name: set_root_key


### PR DESCRIPTION
```
   arp.stats.count_by_intf-out.mgmt0: 2
    arp.stats.count_by_intf-out.total: 2
    cdp.interfaces.stats.count_by_cdp_intf_enabled.enabled: 129
    cdp.interfaces.stats.count_by_cdp_intf_enabled.total: 129
    cdp.interfaces.stats.count_by_port_up.down: 126
    cdp.interfaces.stats.count_by_port_up.total: 129
    cdp.interfaces.stats.count_by_port_up.up: 3
    cdp.neighbors.stats.count_by_intf_id.Ethernet1/2: 3
    cdp.neighbors.stats.count_by_intf_id.mgmt0: 4
    cdp.neighbors.stats.count_by_intf_id.total: 7
    cdp.neighbors.stats.count_by_platform_id.N9K-9000v: 5
    cdp.neighbors.stats.count_by_platform_id.cisco CSR1000V: 2
    cdp.neighbors.stats.count_by_platform_id.total: 7
    interfaces.stats.count_by_admin_state.down: 1
    interfaces.stats.count_by_admin_state.total: 129
    interfaces.stats.count_by_admin_state.up: 128
    interfaces.stats.count_by_eth_bw.1000000: 3
    interfaces.stats.count_by_eth_bw.10000000: 126
    interfaces.stats.count_by_eth_bw.total: 129
    interfaces.stats.count_by_eth_duplex.auto: 126
    interfaces.stats.count_by_eth_duplex.full: 3
    interfaces.stats.count_by_eth_duplex.total: 129
    interfaces.stats.count_by_eth_hw_desc.100/1000/10000 Ethernet: 128
    interfaces.stats.count_by_eth_hw_desc.Ethernet: 1
    interfaces.stats.count_by_eth_hw_desc.total: 129
    interfaces.stats.count_by_state.down: 126
    interfaces.stats.count_by_state.total: 129
    interfaces.stats.count_by_state.up: 3
    interfaces.stats.count_by_state_rsn_desc.Administratively down: 1
    interfaces.stats.count_by_state_rsn_desc.Link not connected: 125
    interfaces.stats.count_by_state_rsn_desc.total: 129
    interfaces.stats.count_by_state_rsn_desc.unknown: 3
    interfaces.switchport.stats.count_by_access_vlan.1: 127
    interfaces.switchport.stats.count_by_access_vlan.total: 127
    interfaces.switchport.stats.count_by_native_vlan.1: 127
    interfaces.switchport.stats.count_by_native_vlan.total: 127
    interfaces.switchport.stats.count_by_oper_mode.access: 127
    interfaces.switchport.stats.count_by_oper_mode.total: 127
    interfaces.switchport.stats.count_by_switchport.Enabled: 127
    interfaces.switchport.stats.count_by_switchport.total: 127
    interfaces.transceiver.stats.count_by_sfp.not applicable: 128
    interfaces.transceiver.stats.count_by_sfp.total: 128
    lldp.interfaces.stats.count_by_lldp_dcbx.N: 1
    lldp.interfaces.stats.count_by_lldp_dcbx.Y: 128
    lldp.interfaces.stats.count_by_lldp_dcbx.total: 129
    lldp.interfaces.stats.count_by_lldp_rx.Y: 129
    lldp.interfaces.stats.count_by_lldp_rx.total: 129
    lldp.interfaces.stats.count_by_lldp_tx.Y: 129
    lldp.interfaces.stats.count_by_lldp_tx.total: 129
    lldp.neighbors.stats.count_by_l_port_id.Eth1/2: 1
    lldp.neighbors.stats.count_by_l_port_id.mgmt0: 1
    lldp.neighbors.stats.count_by_l_port_id.total: 2
    spanning_tree.active.detail.stats.count_by_bpdu_filter.default1: 2
    spanning_tree.active.detail.stats.count_by_bpdu_filter.total: 2
    spanning_tree.active.detail.stats.count_by_bpdu_guard.default1: 2
    spanning_tree.active.detail.stats.count_by_bpdu_guard.total: 2
    spanning_tree.active.detail.stats.count_by_designated_bridge_priority.32768: 1
    spanning_tree.active.detail.stats.count_by_designated_bridge_priority.32769: 1
    spanning_tree.active.detail.stats.count_by_designated_bridge_priority.total: 2
    spanning_tree.active.detail.stats.count_by_designated_cost.0: 1
    spanning_tree.active.detail.stats.count_by_designated_cost.4: 1
    spanning_tree.active.detail.stats.count_by_designated_cost.total: 2
    spanning_tree.active.detail.stats.count_by_dispute.False: 2
    spanning_tree.active.detail.stats.count_by_dispute.total: 2
    spanning_tree.active.detail.stats.count_by_inconsistency.0: 2
    spanning_tree.active.detail.stats.count_by_inconsistency.total: 2
    spanning_tree.active.detail.stats.count_by_oper_bpdufilter.False: 2
    spanning_tree.active.detail.stats.count_by_oper_bpdufilter.total: 2
    spanning_tree.active.detail.stats.count_by_oper_bpduguard.False: 2
    spanning_tree.active.detail.stats.count_by_oper_bpduguard.total: 2
    spanning_tree.active.detail.stats.count_by_oper_loopguard.False: 2
    spanning_tree.active.detail.stats.count_by_oper_loopguard.total: 2
    spanning_tree.active.detail.stats.count_by_oper_networkport.False: 2
    spanning_tree.active.detail.stats.count_by_oper_networkport.total: 2
    spanning_tree.active.detail.stats.count_by_oper_p2p.True: 2
    spanning_tree.active.detail.stats.count_by_oper_p2p.total: 2
    spanning_tree.active.detail.stats.count_by_oper_portfast.False: 2
    spanning_tree.active.detail.stats.count_by_oper_portfast.total: 2
    spanning_tree.active.detail.stats.count_by_peer.stp: 2
    spanning_tree.active.detail.stats.count_by_peer.total: 2
    spanning_tree.active.detail.stats.count_by_port_protocol.rstp: 2
    spanning_tree.active.detail.stats.count_by_port_protocol.total: 2
    spanning_tree.active.detail.stats.count_by_port_tree_type.total: 2
    spanning_tree.active.detail.stats.count_by_port_tree_type.vlan: 2
    spanning_tree.active.detail.stats.count_by_role.designated: 1
    spanning_tree.active.detail.stats.count_by_role.root: 1
    spanning_tree.active.detail.stats.count_by_role.total: 2
    spanning_tree.active.detail.stats.count_by_self_looped.False: 2
    spanning_tree.active.detail.stats.count_by_self_looped.total: 2
    spanning_tree.active.detail.stats.count_by_state.forwarding: 2
    spanning_tree.active.detail.stats.count_by_state.total: 2
    vlan.stats.count_by_vlanshowbr-vlanstate.active: 2
    vlan.stats.count_by_vlanshowbr-vlanstate.total: 2
```